### PR TITLE
Add document fields table for default types

### DIFF
--- a/src/Bundle/PuceneBundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/PuceneBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Pucene\Bundle\PuceneBundle\DependencyInjection;
 
+use Pucene\Component\Mapping\Types;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -84,8 +85,12 @@ class Configuration implements ConfigurationInterface
                                     ->useAttributeAsKey('name')
                                     ->prototype('array')
                                         ->children()
-                                            ->scalarNode('type')->defaultValue('string')->end()
+                                            ->enumNode('type')
+                                                ->values(Types::getTypes())
+                                                ->defaultValue('text')
+                                            ->end()
                                             ->scalarNode('analyzer')->defaultValue('standard')->end()
+                                            ->scalarNode('format')->defaultValue('string')->end()
                                         ->end()
                                     ->end()
                                 ->end()

--- a/src/Bundle/PuceneBundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/PuceneBundle/DependencyInjection/Configuration.php
@@ -90,7 +90,6 @@ class Configuration implements ConfigurationInterface
                                                 ->defaultValue('text')
                                             ->end()
                                             ->scalarNode('analyzer')->defaultValue('standard')->end()
-                                            ->scalarNode('format')->defaultValue('string')->end()
                                         ->end()
                                     ->end()
                                 ->end()

--- a/src/Component/Mapping/Types.php
+++ b/src/Component/Mapping/Types.php
@@ -5,7 +5,7 @@ namespace Pucene\Component\Mapping;
 /**
  * Mapping types.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
  */
 class Types
 {

--- a/src/Component/Mapping/Types.php
+++ b/src/Component/Mapping/Types.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Pucene\Component\Mapping;
+
+/**
+ * Mapping types.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
+ */
+class Types
+{
+    // String Types
+    const TEXT = 'text';
+    const KEYWORD = 'keyword';
+
+    // Numeric Types
+    const LONG = 'long';
+    const INTEGER = 'integer';
+    const SHORT = 'short';
+    const BYTE = 'byte';
+    const DOUBLE = 'double';
+    const FLOAT = 'float';
+    const HALF_FLOAT = 'half_float';
+    const SCALED_FLOAT = 'scaled_float';
+
+    // Date types
+    const DATE = 'date';
+
+    // Boolean types
+    const BOOLEAN = 'boolean';
+
+    // Binary types
+    const BINARY = 'binary';
+
+    /**
+     * Get types.
+     *
+     * @return string[]
+     */
+    public static function getTypes()
+    {
+        return [
+            self::TEXT,
+            self::KEYWORD,
+            self::LONG,
+            self::INTEGER,
+            self::SHORT,
+            self::BYTE,
+            self::DOUBLE,
+            self::FLOAT,
+            self::HALF_FLOAT,
+            self::SCALED_FLOAT,
+            self::DATE,
+            self::BOOLEAN,
+            self::BINARY,
+        ];
+    }
+
+    /**
+     * Get string types.
+     *
+     * @return string[]
+     */
+    public static function getStringTypes()
+    {
+        return [
+            self::TEXT,
+            self::KEYWORD,
+        ];
+    }
+
+    /**
+     * Get numeric types.
+     *
+     * @return string[]
+     */
+    public static function getNumericTypes()
+    {
+        return [
+            self::LONG,
+            self::INTEGER,
+            self::SHORT,
+            self::BYTE,
+            self::DOUBLE,
+            self::FLOAT,
+            self::HALF_FLOAT,
+            self::SCALED_FLOAT,
+        ];
+    }
+
+    /**
+     * Get integer types.
+     *
+     * @return string[]
+     */
+    public static function getIntegerTypes()
+    {
+        return [
+            self::LONG,
+            self::INTEGER,
+            self::SHORT,
+            self::BYTE,
+        ];
+    }
+
+    /**
+     * Get float types.
+     *
+     * @return array
+     */
+    public static function getFloatTypes()
+    {
+        return [
+            self::DOUBLE,
+            self::FLOAT,
+            self::HALF_FLOAT,
+            self::SCALED_FLOAT,
+        ];
+    }
+}

--- a/src/Component/Pucene/Dbal/PuceneSchema.php
+++ b/src/Component/Pucene/Dbal/PuceneSchema.php
@@ -30,6 +30,7 @@ class PuceneSchema
         $this->createDocumentsTable();
         $this->createTokensTable();
         $this->createDocumentTermsTable();
+        $this->createDocumentFieldsTabe();
     }
 
     private function createDocumentsTable()
@@ -42,6 +43,7 @@ class PuceneSchema
         $documents->addColumn('type', 'string', ['length' => 255]);
         $documents->addColumn('document', 'json_array');
         $documents->addColumn('indexed_at', 'datetime');
+
         $documents->setPrimaryKey(['id']);
         $documents->addIndex(['type']);
         $documents->addUniqueIndex(['number']);
@@ -62,8 +64,14 @@ class PuceneSchema
         $fields->addColumn('type', 'string', ['length' => 255]);
         $fields->addColumn('term_frequency', 'integer');
         $fields->addColumn('field_norm', 'float');
+
         $fields->setPrimaryKey(['id']);
-        $fields->addForeignKeyConstraint($this->tableNames['documents'], ['document_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $fields->addForeignKeyConstraint(
+            $this->tableNames['documents'],
+            ['document_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE']
+        );
         $fields->addIndex(['field_name', 'term']);
     }
 
@@ -76,6 +84,7 @@ class PuceneSchema
         $fields->addColumn('document_id', 'string', ['length' => 255]);
         $fields->addColumn('term', 'string', ['length' => 255]);
         $fields->addColumn('frequency', 'integer');
+
         $fields->setPrimaryKey(['id']);
         $fields->addForeignKeyConstraint(
             $this->tableNames['documents'],
@@ -84,6 +93,32 @@ class PuceneSchema
             ['onDelete' => 'CASCADE']
         );
         $fields->addIndex(['term']);
+    }
+
+    private function createDocumentFieldsTabe()
+    {
+        $this->tableNames['document_fields'] = sprintf('pu_%s_document_fields', $this->prefix);
+
+        $fields = $this->schema->createTable($this->tableNames['document_fields']);
+        $fields->addColumn('id', 'integer', ['autoincrement' => true]);
+        $fields->addColumn('document_id', 'string', ['length' => 255]);
+        $fields->addColumn('field_name', 'string', ['length' => 255]);
+        $fields->addColumn('text', 'text', ['nullable' => true]);
+        $fields->addColumn('keyword', 'text', ['nullable' => true]);
+        $fields->addColumn('date', 'datetime', ['nullable' => true]);
+        $fields->addColumn('long', 'bigint', ['nullable' => true]);
+        $fields->addColumn('double', 'double', ['nullable' => true]);
+        $fields->addColumn('boolean', 'boolean', ['nullable' => true]);
+        $fields->addColumn('ip', 'bigint', ['nullable' => true]);
+
+        $fields->setPrimaryKey(['id']);
+        $fields->addForeignKeyConstraint(
+            $this->tableNames['documents'],
+            ['document_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE']
+        );
+        $fields->addIndex(['field_name']);
     }
 
     public function toSql(AbstractPlatform $platform)

--- a/src/Component/Pucene/Dbal/PuceneSchema.php
+++ b/src/Component/Pucene/Dbal/PuceneSchema.php
@@ -99,7 +99,7 @@ class PuceneSchema
     /**
      * Create table per mapping type.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
      */
     private function createDocumentFieldsTables()
     {

--- a/src/Component/Pucene/Dbal/PuceneSchema.php
+++ b/src/Component/Pucene/Dbal/PuceneSchema.php
@@ -106,7 +106,7 @@ class PuceneSchema
         $fields->addColumn('keyword', 'text', ['nullable' => true]);
         $fields->addColumn('date', 'datetime', ['nullable' => true]);
         $fields->addColumn('long', 'bigint', ['nullable' => true]);
-        $fields->addColumn('double', 'double', ['nullable' => true]);
+        $fields->addColumn('double', 'float', ['nullable' => true]);
         $fields->addColumn('boolean', 'boolean', ['nullable' => true]);
         $fields->addColumn('ip', 'bigint', ['nullable' => true]);
 

--- a/src/Component/Pucene/Dbal/PuceneSchema.php
+++ b/src/Component/Pucene/Dbal/PuceneSchema.php
@@ -64,6 +64,7 @@ class PuceneSchema
         $fields->addColumn('type', 'string', ['length' => 255]);
         $fields->addColumn('term_frequency', 'integer', ['default' => 0]);
         $fields->addColumn('field_norm', 'float', ['default' => 0]);
+        
         $fields->setPrimaryKey(['id']);
         $fields->addForeignKeyConstraint(
             $this->tableNames['documents'],


### PR DESCRIPTION
Added document field types table for [simple data types](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)
